### PR TITLE
fix: Replace deprecated 'ready' event with 'clientReady'

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ integrate with slash commands
 */
 
 //client initiated and is ready
-client.on("ready", () => {
+client.on("clientReady", () => {
 	try {
 		handleOnReady(client);
 	} catch (err) {


### PR DESCRIPTION
The 'ready' event has been renamed to 'clientReady' to distinguish it from the gateway READY event. Using 'ready' now triggers a deprecation warning in discord.js v14 and will be removed in v15.